### PR TITLE
[AIRFLOW-3384] Allow higher versions of Sqlalchemy and Jinja2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -300,7 +300,7 @@ def do_setup():
             'dill>=0.2.2, <0.3',
             'flask>=0.12.4, <0.13',
             'flask-appbuilder==1.12.1',
-            'flask-admin==1.4.1',
+            'flask-admin==1.5.2',
             'flask-caching>=1.3.3, <1.4.0',
             'flask-login>=0.3, <0.5',
             'flask-swagger==0.2.13',


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### Jira

-  My PR addresses this JIRA issue: [AIRFLOW-3384]

### Description

- [This PR bumps up the allowed versions of sqlalchemy and jinja2

### Tests

- This PR does not add new functionality to be tested, nor changes the codebase.

